### PR TITLE
Remove top-level documentation warning

### DIFF
--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -14,3 +14,9 @@ Style/AccessorMethodName:
 
 Style/InlineComment:
   Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false


### PR DESCRIPTION
Annoying warning that isn't all that useful.

`Missing top-level class documentation comment.`