### PR TITLE
allow class definitions over 100 lines

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -99,7 +99,7 @@ Style/ClassCheck:
 
 Style/ClassLength:
   Description: 'Avoid classes longer than 100 lines of code.'
-  Enabled: true
+  Enabled: false
 
 Style/ClassMethods:
   Description: 'Use self when defining module/class methods.'


### PR DESCRIPTION
@bigcommerce-labs/tools 

Many of our class definitions are over 100 lines long. With rubocop able to fail travis runs it seems unreasonable to keep this check in place. 
